### PR TITLE
Dump Custom objects with slots

### DIFF
--- a/jsonrpclib/jsonclass.py
+++ b/jsonrpclib/jsonclass.py
@@ -120,7 +120,10 @@ def dump(obj, serialize_method=None, ignore_attribute=None, ignore=[],
         return_obj['__jsonclass__'].append([])
         attrs = {}
         ignore_list = getattr(obj, ignore_attribute, []) + ignore
-        for attr_name, attr_value in obj.__dict__.items():
+        props = getattr(obj, "__dict__", {})
+        if hasattr(obj, "__slots__"):
+            props.update(((k, getattr(obj, k)) for k in obj.__slots__))
+        for attr_name, attr_value in props.items():
             if isinstance(attr_value, supported_types) and \
                     attr_name not in ignore_list and \
                     attr_value not in ignore_list:


### PR DESCRIPTION
Sending request to server results in  exception:

```
Traceback (most recent call last):
  File "C:\Utilities\eclipse\plugins\org.python.pydev_3.5.0.201405201709\pysrc\pydevd.py", line 1845, in <module>
    debugger.run(setup['file'], None, None)
  File "C:\Utilities\eclipse\plugins\org.python.pydev_3.5.0.201405201709\pysrc\pydevd.py", line 1373, in run
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "D:\Data\Workspace\test_samples_utilities\jsonrpc_test.py", line 15, in <module>
    auth = s.ana_rpc("", "login", auth_login_encode("guest", "guest"))["result"]
  File "build\bdist.win32\egg\jsonrpclib\jsonrpc.py", line 446, in __call__
  File "build\bdist.win32\egg\jsonrpclib\jsonrpc.py", line 349, in _request
  File "build\bdist.win32\egg\jsonrpclib\jsonrpc.py", line 906, in check_for_errors
jsonrpclib.jsonrpc.ProtocolError: (-32603, u"<type 'exceptions.AttributeError'>:'MessagingObject' object has no attribute '__dict__'")
```

Looking into MessagingObject I found out that it is an object which has defined __slots__ and thus it does not have a __dict__.

I made some modifications to get object with slots to response.
