### PR TITLE
Dump user defined types with handler functions (can be used to override dump of built-in types)

### DIFF
--- a/jsonrpclib/config.py
+++ b/jsonrpclib/config.py
@@ -56,7 +56,8 @@ class Config(object):
     def __init__(self, version=2.0, content_type="application/json-rpc",
                  user_agent=None, use_jsonclass=True,
                  serialize_method='_serialize',
-                 ignore_attribute='_ignore'):
+                 ignore_attribute='_ignore',
+                 serialize_handlers={}):
         """
         Sets up a configuration of JSONRPClib
 
@@ -72,6 +73,9 @@ class Config(object):
                                  custom class object which holds strings and/or
                                  references of the attributes the class
                                  translator should ignore.
+        :param serialize_handlers: A dictionary of dump handler functions by
+                                   type for additional type support and for
+                                   overriding dump of built-in types in utils
         """
         # JSON-RPC specification
         self.version = version
@@ -103,6 +107,12 @@ class Config(object):
         # attribute on a custom class object which holds strings and / or
         # references of the attributes the class translator should ignore.
         self.ignore_attribute = ignore_attribute
+
+        # The list of serialize handler functions for jsonclass dump.
+        # Used for handling additional types and overriding built-in types.
+        # Functions are expected to have the same parameters as jsonclass dump
+        # (possibility to call standard jsonclass dump function within).
+        self.serialize_handlers = serialize_handlers
 
 # Default configuration
 DEFAULT = Config()

--- a/jsonrpclib/jsonclass.py
+++ b/jsonrpclib/jsonclass.py
@@ -77,8 +77,13 @@ def dump(obj, serialize_method=None, ignore_attribute=None, ignore=[],
         ignore_attribute = config.ignore_attribute
 
     # Parse / return default "types"...
+    # Apply additional types, override built-in types
+    if isinstance(obj, tuple(config.serialize_handlers)):
+    	return config.serialize_handlers[type(obj)](obj, serialize_method, 
+     	                                            ignore_attribute, ignore)
+
     # Primitive
-    if isinstance(obj, utils.primitive_types):
+    elif isinstance(obj, utils.primitive_types):
         return obj
 
     # Iterative
@@ -123,8 +128,9 @@ def dump(obj, serialize_method=None, ignore_attribute=None, ignore=[],
         props = getattr(obj, "__dict__", {})
         if hasattr(obj, "__slots__"):
             props.update(((k, getattr(obj, k)) for k in obj.__slots__))
+        known_types = supported_types + tuple(config.serialize_handlers)
         for attr_name, attr_value in props.items():
-            if isinstance(attr_value, supported_types) and \
+            if isinstance(attr_value, known_types) and \
                     attr_name not in ignore_list and \
                     attr_value not in ignore_list:
                 attrs[attr_name] = dump(attr_value, serialize_method,


### PR DESCRIPTION
A dictionary of dump handler functions by type added to Config for additional type support in jsonclass dump. Implemented in such manner that it can be used for overriding dump of built-in types (defined in utils).
