### PR TITLE
jsonrpclib: Fix TransportMixin implementation.

### DIFF
--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -359,6 +359,7 @@ class TransportMixIn(object):
         connection = self.make_connection(host)
         try:
             self.send_request(connection, handler, request_body, verbose)
+            self.send_content(connection, request_body)
 
             response = connection.getresponse()
             if response.status == 200:
@@ -397,7 +398,6 @@ class TransportMixIn(object):
         else:
             connection.putrequest("POST", handler)
 
-        self.send_content(connection, request_body)
         return connection
 
     def send_content(self, connection, request_body):


### PR DESCRIPTION
The send_request implementation in TransportMixin erroneously sent the
request body (it is only supposed to send the "POST" line and
headers). This is not a problem with py2.7, because there the
XMLTransport class from xmlrpclib invokes single_request, which is
implemented in jsonrpclib and expects this wrong behavior. The py2.6
xmlrpc lib instead invokes send_request, emits some more headers and
then invokes sent content. As the bad send_request already sent the
content, the attempt to add more headers afterwards failed.

This patch removes the send_content call from send_request and adds it
in single_request instead.