### PR TITLE
fix returned exception in case of several lines in error

### DIFF
--- a/jsonrpclib/SimpleJSONRPCServer.py
+++ b/jsonrpclib/SimpleJSONRPCServer.py
@@ -384,8 +384,8 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCDispatcher, object):
                 return fault
             except:
                 # Method exception
-                err_lines = traceback.format_exc().splitlines()
-                trace_string = '{0} | {1}'.format(err_lines[-3], err_lines[-1])
+                err_lines = traceback.format_exception(*sys.exc_info())
+                trace_string = '{0} | {1}'.format(err_lines[-2].splitlines()[0].strip(), err_lines[-1])
                 fault = Fault(-32603, 'Server error: {0}'.format(trace_string),
                               config=config)
                 _logger.exception("Server-side exception: %s", fault)
@@ -451,8 +451,8 @@ class SimpleJSONRPCRequestHandler(SimpleXMLRPCRequestHandler):
         except:
             # Exception: send 500 Server Error
             self.send_response(500)
-            err_lines = traceback.format_exc().splitlines()
-            trace_string = '{0} | {1}'.format(err_lines[-3], err_lines[-1])
+            err_lines = traceback.format_exception(*sys.exc_info())
+            trace_string = '{0} | {1}'.format(err_lines[-2].splitlines()[0].strip(), err_lines[-1])
             fault = jsonrpclib.Fault(-32603, 'Server error: {0}'
                                      .format(trace_string), config=config)
             _logger.exception("Server-side error: %s", fault)


### PR DESCRIPTION
Exceptions at server side with several lines message, are not processed as they should.

`raise Exception('Several\nlines\nexception')`