### PR TITLE
jsonrpc: Don't proxy "special" methods

### DIFF
--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -583,6 +583,9 @@ class ServerProxy(XMLServerProxy):
         """
         Returns a callable object to call the remote service
         """
+        if name.startswith("__") and name.endswith("__"):
+            # Don't proxy special methods.
+            raise AttributeError("ServerProxy has no attribute '%s'" % name)
         # Same as original, just with new _Method reference
         return _Method(self._request, name)
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -113,6 +113,10 @@ class TestCompatibility(unittest.TestCase):
         self.assertTrue(request == verify_request)
         self.assertTrue(response == verify_response)
 
+    def test_special_method(self):
+        self.assertRaises(AttributeError, getattr, self.client, '__special_method__')
+        self.assertIsNone(self.history.request)
+
     def test_invalid_json(self):
         invalid_json = '{"jsonrpc": "2.0", "method": "foobar, ' + \
             '"params": "bar", "baz]'


### PR DESCRIPTION
As discussed in #32: Refuse to provide method proxies for double-underscore methods.
