### PR TITLE
SimpleJSONRPCServer.py: fix logging

### DIFF
--- a/jsonrpclib/SimpleJSONRPCServer.py
+++ b/jsonrpclib/SimpleJSONRPCServer.py
@@ -88,6 +88,7 @@ __version__ = ".".join(str(x) for x in __version_info__)
 __docformat__ = "restructuredtext en"
 
 # Prepare the logger
+logging.basicConfig()
 _logger = logging.getLogger(__name__)
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
server's code:

```
from jsonrpclib.SimpleJSONRPCServer import PooledJSONRPCServer
from jsonrpclib.threadpool import ThreadPool
...
...
pool = ThreadPool(max_threads=50, min_threads=10)
pool.start()
server = PooledJSONRPCServer((IP, PORT), thread_pool=pool)

# All rigistred methods
server.register_function(foo)
...
```

When i call (on client side) unregistered method, i see in server logs:
```
Oct 03 12:04:52 dc01.dc.int.c2.croc.ru python[22924]: No handlers could be found for logger "jsonrpclib.SimpleJSONRPCServer"
Oct 03 12:04:52 dc01.dc.int.c2.croc.ru python[22924]: 172.20.36.102 - - [03/Oct/2019 12:04:52] "POST / HTTP/1.1" 200 -
```

after this fix, logging works correctly:
```
Oct 03 12:14:59 dc01.dc.int.c2.croc.ru python[25408]: WARNING:jsonrpclib.SimpleJSONRPCServer:Unknown method: <Fault -32601: Method test not supported.>
Oct 03 12:14:59 dc01.dc.int.c2.croc.ru python[25408]: 172.20.36.102 - - [03/Oct/2019 12:14:59] "POST / HTTP/1.1" 200 -
...
Oct 03 12:18:03 dc01.dc.int.c2.croc.ru python[25408]: WARNING:jsonrpclib.SimpleJSONRPCServer:Invalid call parameters: <Fault -32602: Invalid parameters: update() takes no arguments (1 given)>
Oct 03 12:18:03 dc01.dc.int.c2.croc.ru python[25408]: 172.20.36.102 - - [03/Oct/2019 12:18:03] "POST / HTTP/1.1" 200 -
```