### PR TITLE
Fixed missing code in docs

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -51,7 +51,7 @@ The easiest way to do it is to add those lines at the beginning of your code:
 .. code-block:: python
 
    import logging
-   logging.basiConfig()
+   logging.basicConfig()
 
 More information can be found in the
 `logging documentation page <https://docs.python.org/3/library/logging.html>`_.

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -52,6 +52,7 @@ As a result, you have to configure the Python logging to print out traces.
 The easiest way to do it is to add those lines at the beginning of your code:
 
 .. code-block:: python
+
    import logging
    logging.basiConfig()
 

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -42,9 +42,6 @@ To start protect the server with SSL, use the following snippet:
 A note on logging
 =================
 
-
-## A note on logging
-
 ``jsonrpclib-pelix`` uses the ``logging`` module from the standard Python
 library to trace warnings and errors, but doesn't set it up.
 As a result, you have to configure the Python logging to print out traces.


### PR DESCRIPTION
Extra line is required after `code-block:: python`