### PR TITLE
Improve HTTP/1.1 compliance for unix sockets

### DIFF
--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -491,7 +491,10 @@ class UnixHTTPConnection(HTTPConnection):
 
         :param path: Path to the Unix socket
         """
-        HTTPConnection.__init__(self, path, *args, **kwargs)
+
+        # Use localhost as the hostname since a HTTP/1.1 client MUST send a
+        # 'Host:' header.
+        HTTPConnection.__init__(self, 'localhost', *args, **kwargs)
         self.path = path
 
     def connect(self):


### PR DESCRIPTION
Send 'Host: localhost' header for better interoperability

RFC7230 [1] requires that a hostname MUST be sent for HTTP/1.1 requests. Currently, the path is sent which breaks some jsonrpc servers that do not permit the invalid '/' character in a host name. 'localhost' was chosen since the client intends to communicate with the localhost via unix domain socket.

[1] https://tools.ietf.org/html/rfc7230#section-5.4