### PR TITLE
Add TransportError subclass of ProtocolError

### DIFF
--- a/jsonrpclib/__init__.py
+++ b/jsonrpclib/__init__.py
@@ -27,7 +27,8 @@ Aliases to ease access to jsonrpclib classes
 
 # Easy access to utility methods and classes
 from jsonrpclib.jsonrpc import Server, ServerProxy
-from jsonrpclib.jsonrpc import MultiCall, Fault, ProtocolError, AppError
+from jsonrpclib.jsonrpc import ( MultiCall, Fault,
+                                 ProtocolError, AppError, TransportError )
 from jsonrpclib.jsonrpc import loads, dumps, load, dump
 from jsonrpclib.jsonrpc import jloads, jdumps
 import jsonrpclib.history as history

--- a/jsonrpclib/jsonrpc.py
+++ b/jsonrpclib/jsonrpc.py
@@ -202,6 +202,22 @@ class AppError(ProtocolError):
         return self.args[0][2]
 
 
+class TransportError( ProtocolError ):
+    def __init__(self, url, errcode, errmsg, msg):
+        ProtocolError.__init__(self, url, errcode, errmsg, msg)
+
+        self.url = url
+        self.errcode = errcode
+        self.errmsg = errmsg
+        self.msg = msg
+
+    def __repr__(self):
+        return (
+             "<%s for %s: %s %s>" %
+            (self.__class__.__name__, self.url, self.errcode, self.errmsg)
+        )
+
+
 class JSONParser(object):
     """
     Default JSON parser
@@ -386,7 +402,7 @@ class TransportMixIn(object):
         # Discard any response data and raise exception
         if response.getheader("content-length", 0):
             response.read()
-        raise ProtocolError(host + handler,
+        raise TransportError(host + handler,
                             response.status, response.reason,
                             response.msg)
 

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -165,3 +165,14 @@ class InternalTests(unittest.TestCase):
                 def func():
                     return result[i]
                 self.assertRaises(raises[i], func)
+
+    def test_tranport_error(self):
+        """
+        test http error handling
+        """
+        badserver = jsonrpclib.ServerProxy(
+            "http://localhost:{0}/pathdoesnotexist".format(self.port),
+            history=self.history
+        )
+
+        self.assertRaises( jsonrpclib.TransportError, badserver.foo )


### PR DESCRIPTION
The backwards compatible TransportError simplifies client error handling by
providing dedicated subclass with attribute access for error details.