### PR TITLE
Bug fix: add handling of decimal.Decimal value to jsonclass.py

### DIFF
--- a/jsonrpclib/jsonclass.py
+++ b/jsonrpclib/jsonclass.py
@@ -176,6 +176,9 @@ def dump(
         params, attrs = serialize()
         return_obj["__jsonclass__"].append(params)
         return_obj.update(attrs)
+    elif utils.is_decimal(obj):
+        # Add parameter for Decimal that works with JSON
+        return_obj["__jsonclass__"].append([str(obj)])
     elif utils.is_enum(obj):
         # Add parameters for enumerations
         return_obj["__jsonclass__"].append([obj.value])

--- a/jsonrpclib/utils.py
+++ b/jsonrpclib/utils.py
@@ -122,6 +122,34 @@ except ImportError:
 
 
 # ------------------------------------------------------------------------------
+# Decimal
+
+try:
+    import decimal
+
+    def is_decimal(obj):
+        """
+        Checks if an object is a decimal.Decimal
+
+        :param obj: Object to test
+        :return: True if the object is a Decimal
+        """
+        return isinstance(obj, decimal.Decimal)
+
+
+except ImportError:
+    # Decimal introduced in Python 2.4
+    def is_decimal(obj):  # pylint: disable=unused-argument
+        """
+        Before Python 2.4, Decimal did not exist.
+
+        :param obj: Object to test
+        :return: Always False
+        """
+        return False
+
+
+# ------------------------------------------------------------------------------
 # Common
 
 DictType = dict

--- a/tests/test_jsonclass.py
+++ b/tests/test_jsonclass.py
@@ -28,6 +28,12 @@ try:
 except ImportError:
     enum = None  # type: ignore
 
+try:
+    from decimal import Decimal
+except ImportError:
+    Decimal = None
+
+
 # JSON-RPC library
 from jsonrpclib.jsonclass import dump, load
 import jsonrpclib.config
@@ -365,3 +371,17 @@ class SerializationTests(unittest.TestCase):
         serialized = dump(data)
         result = load(serialized)
         self.assertListEqual(data, result)
+
+    def test_decimal(self):
+        """
+        Tests the serialization of decimal.Decimal
+        """
+        if Decimal is None:
+            self.skipTest("decimal package not available.")
+
+        for d in (1.1, "3.2"):
+            d_dec = Decimal(d)
+            serialized = dump(d_dec)
+            result = load(serialized)
+            self.assertIsInstance(result, Decimal)
+            self.assertEqual(result, d_dec)


### PR DESCRIPTION
The dump() method in jsonclass was emitting a list with "decimal.Decimal" - the correct module and class name, but no value to be used in deserialization was included. The net effect was all Decimal's being transported came through with the default value of 0.

This pull requests fixes this by including the string representation of the Decimal to be used by load() on deserialization.

A test case is included.